### PR TITLE
Remove buffered channels

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -126,7 +126,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 	var err error
 	once.Do(func() {
 		runCtx, runCancel = context.WithCancel(context.Background())
-		theChannel = make(chan Message, 1)
+		theChannel = make(chan Message)
 		go func() {
 			err = theInput.Collect(runCtx, theChannel)
 		}()
@@ -185,7 +185,7 @@ func FLBPluginFlush(data unsafe.Pointer, clength C.int, ctag *C.char) int {
 	var err error
 	once.Do(func() {
 		runCtx, runCancel = context.WithCancel(context.Background())
-		theChannel = make(chan Message, 1)
+		theChannel = make(chan Message)
 		go func() {
 			err = theOutput.Flush(runCtx, theChannel)
 		}()


### PR DESCRIPTION
As per discussion with @nicolasparada . No need for a buffered channel when receiving/collecting and flushing messages.