### PR TITLE
cshared: free the input buffer in a cleanup callback.

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -170,6 +170,13 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 	return input.FLB_OK
 }
 
+// FLBPluginInputCleanupCallback releases the memory used during the input callback
+//export FLBPluginInputCleanupCallback
+func FLBPluginInputCleanupCallback(data unsafe.Pointer) int {
+	C.free(data)
+	return input.FLB_OK
+}
+
 // FLBPluginFlush callback gets invoked by the fluent-bit runtime once there is data for the corresponding
 // plugin in the pipeline, a data pointer, length and a tag are passed to the plugin interface implementation.
 //export FLBPluginFlush


### PR DESCRIPTION
Add a FLBPluginInputCleanupCallback to free up the memory that is allocated in the input callback. Fixes calyptia/lts-advanced-plugin-s3-replay#59.