### PR TITLE
[FEATURE] buffered channel drain

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -183,6 +183,9 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 				case <-t.C:
 					buflock.Unlock()
 					buflock.Lock()
+				case <-runCtx.Done():
+					buflock.Unlock()
+					return
 				}
 				buflock.Unlock()
 			}

--- a/cshared.go
+++ b/cshared.go
@@ -38,7 +38,7 @@ var (
 
 const (
 	collectInterval = time.Nanosecond * 1000
-
+	maxBufferedMessages = 300000
 )
 
 // FLBPluginRegister registers a plugin in the context of the fluent-bit runtime, a name and description
@@ -141,7 +141,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 	once.Do(func() {
 		runCtx, runCancel = context.WithCancel(context.Background())
 		// we need to configure this part....
-		theChannel = make(chan Message, 300000)
+		theChannel = make(chan Message, maxBufferedMessages)
 		// do we need to buffer this part???
 		cbuf := make(chan Message, 16)
 

--- a/cshared.go
+++ b/cshared.go
@@ -138,7 +138,6 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		return input.FLB_RETRY
 	}
 
-	var err error
 	once.Do(func() {
 		runCtx, runCancel = context.WithCancel(context.Background())
 		// we need to configure this part....
@@ -196,10 +195,6 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 			}
 		}(cbuf)
 	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "run: %s\n", err)
-		return input.FLB_ERROR
-	}
 
 	buf := bytes.NewBuffer([]byte{})
 

--- a/cshared.go
+++ b/cshared.go
@@ -36,6 +36,11 @@ var (
 	buflock    sync.Mutex
 )
 
+const (
+	collectInterval = time.Nanosecond * 1000
+
+)
+
 // FLBPluginRegister registers a plugin in the context of the fluent-bit runtime, a name and description
 // can be provided.
 //
@@ -146,7 +151,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		// behavior and also simulate the original behavior for those plugins that
 		// do not hold on to the thread.
 		go func(runCtx context.Context) {
-			t := time.NewTicker(1000 * time.Nanosecond)
+			t := time.NewTicker(collectInterval)
 			defer t.Stop()
 
 			for {

--- a/cshared.go
+++ b/cshared.go
@@ -257,7 +257,8 @@ func FLBPluginInputCleanupCallback(data unsafe.Pointer) int {
 // plugin in the pipeline, a data pointer, length and a tag are passed to the plugin interface implementation.
 //
 //export FLBPluginFlush
-//nolint:funlen,gocognit,gocyclo //ignore length requirement for this function, TODO: refactor into smaller functions.
+// TODO: refactor into smaller functions.
+//nolint:funlen //ignore length requirement for this function
 func FLBPluginFlush(data unsafe.Pointer, clength C.int, ctag *C.char) int {
 	initWG.Wait()
 

--- a/cshared.go
+++ b/cshared.go
@@ -146,6 +146,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		}()
 		go func(cbuf chan Message) {
 			t := time.NewTicker(1 * time.Second)
+			defer t.Stop()
 			for {
 				buflock.Lock()
 				select {

--- a/cshared.go
+++ b/cshared.go
@@ -65,7 +65,7 @@ func FLBPluginRegister(def unsafe.Pointer) int {
 }
 
 // FLBPluginInit this method gets invoked once by the fluent-bit runtime at initialisation phase.
-// here all the plugin context should be initialised and any data or flag required for
+// here all the plugin context should be initialized and any data or flag required for
 // plugins to execute the collect or flush callback.
 //
 //export FLBPluginInit
@@ -120,7 +120,7 @@ func FLBPluginInit(ptr unsafe.Pointer) int {
 }
 
 // FLBPluginInputCallback this method gets invoked by the fluent-bit runtime, once the plugin has been
-// initialised, the plugin implementation is responsible for handling the incoming data and the context
+// initialized, the plugin implementation is responsible for handling the incoming data and the context
 // that gets past, for long-living collectors the plugin itself should keep a running thread and fluent-bit
 // will not execute further callbacks.
 //
@@ -143,7 +143,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 
 		// Most plugins expect Collect to be invoked once and then takes over the
 		// input thread by running in an infinite loop. Here we simulate this
-		// behaviour and also simulate the original behaviour for those plugins that
+		// behavior and also simulate the original behavior for those plugins that
 		// do not hold on to the thread.
 		go func(runCtx context.Context) {
 			t := time.NewTicker(1000 * time.Nanosecond)
@@ -155,7 +155,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 					return
 				case <-t.C:
 					if err := theInput.Collect(runCtx, cbuf); err != nil {
-						fmt.Fprintf("Error collecting input: %s\n", err)
+						fmt.Fprintf(os.Stderr, "Error collecting input: %s\n", err)
 					}
 				}
 			}

--- a/cshared.go
+++ b/cshared.go
@@ -134,7 +134,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 	var err error
 	once.Do(func() {
 		runCtx, runCancel = context.WithCancel(context.Background())
-		theChannel = make(chan Message, 16)
+		theChannel = make(chan Message, 256)
 		go func() {
 			err = theInput.Collect(runCtx, theChannel)
 		}()

--- a/cshared.go
+++ b/cshared.go
@@ -159,7 +159,6 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 				case <-t.C:
 					buflock.Unlock()
 					buflock.Lock()
-				default:
 				}
 				buflock.Unlock()
 			}

--- a/cshared.go
+++ b/cshared.go
@@ -155,7 +155,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 					return
 				case <-t.C:
 					if err := theInput.Collect(runCtx, cbuf); err != nil {
-						fmt.Fprintf(os.Stderr, "Error collecting input: %s\n", err)
+						fmt.Fprintf(os.Stderr, "Error collecting input: %s\n", err.Error())
 					}
 				}
 			}

--- a/cshared.go
+++ b/cshared.go
@@ -142,7 +142,9 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		cbuf := make(chan Message, 16)
 
 		go func() {
-			err = theInput.Collect(runCtx, cbuf)
+			if err := theInput.Collect(runCtx, cbuf); err != nil {
+				fmt.Fprintf("Error collecting input: %s\n", err)
+			}
 		}()
 		go func(cbuf chan Message) {
 			t := time.NewTicker(1 * time.Second)


### PR DESCRIPTION
# Summary

Refactor go plugins to drain messages with buffering.

# Description

This PR refactors the `cshared` layer so that it uses a buffered go channel. This improves the throughput tremendously.

This is part of an effort to previously improve the S3 plugin during a PoC.
