### PR TITLE
output: Handle metadata on Fluent Bit V2 format

### DIFF
--- a/output/decoder.go
+++ b/output/decoder.go
@@ -83,7 +83,22 @@ func GetRecord(dec *FLBDecoder) (ret int, ts interface{}, rec map[interface{}]in
 		return -2, 0, nil
 	}
 
-	t := slice.Index(0).Interface()
+	var t interface{}
+	ts = slice.Index(0).Interface()
+	switch ty := ts.(type) {
+	case FLBTime:
+		t = ty
+	case uint64:
+		t = ty
+	case []interface{}: // for Fluent Bit V2 metadata type of format
+		s := reflect.ValueOf(ty)
+		if s.Kind() != reflect.Slice || s.Len() < 2 {
+			return -4, 0, nil
+		}
+		t = s.Index(0).Interface()
+	default:
+		return -5, 0, nil
+	}
 	data := slice.Index(1)
 
 	map_data := data.Interface().(map[interface{}]interface{})


### PR DESCRIPTION
# Summary

Implement to handle Fluent Bit V2 capability.

# Description

This PR adds a capability to handle Fluent Bit V2 format of metadata. This format should be handled as `interface{}` at first and needed to decompose to obtain timestamps.