### PR TITLE
unescape literal new-line

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -331,10 +332,21 @@ type flbInputConfigLoader struct {
 }
 
 func (f *flbInputConfigLoader) String(key string) string {
-	s := input.FLBPluginConfigKey(f.ptr, key)
+	return unquote(input.FLBPluginConfigKey(f.ptr, key))
+}
+
+func unquote(s string) string {
 	if tmp, err := strconv.Unquote(s); err == nil {
 		return tmp
 	}
+
+	// unescape literal newlines
+	if strings.Contains(s, `\n`) {
+		if tmp2, err := strconv.Unquote(`"` + s + `"`); err == nil {
+			return tmp2
+		}
+	}
+
 	return s
 }
 
@@ -343,11 +355,7 @@ type flbOutputConfigLoader struct {
 }
 
 func (f *flbOutputConfigLoader) String(key string) string {
-	s := output.FLBPluginConfigKey(f.ptr, key)
-	if tmp, err := strconv.Unquote(s); err == nil {
-		return tmp
-	}
-	return s
+	return unquote(output.FLBPluginConfigKey(f.ptr, key))
 }
 
 type flbInputLogger struct {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -139,16 +139,18 @@ func testPlugin(t *testing.T, pool *dockertest.Pool) {
 				}
 
 				var got struct {
-					Foo     string `json:"foo"`
-					Message string `json:"message"`
-					Tmpl    string `json:"tmpl"`
+					Foo            string   `json:"foo"`
+					Message        string   `json:"message"`
+					TmplOut        string   `json:"tmpl_out"`
+					MultilineSplit []string `json:"multiline_split"`
 				}
 
 				err := json.Unmarshal([]byte(line), &got)
 				assert.NoError(t, err)
 				assert.Equal(t, "bar", got.Foo)
 				assert.Equal(t, "hello from go-test-input-plugin", got.Message)
-				assert.Equal(t, "inside double quotes\nnew line", got.Tmpl)
+				assert.Equal(t, "inside double quotes\nnew line", got.TmplOut)
+				assert.Equal(t, []string{"foo", "bar"}, got.MultilineSplit)
 
 				t.Logf("took %s", time.Since(start))
 

--- a/testdata/fluent-bit.conf
+++ b/testdata/fluent-bit.conf
@@ -8,6 +8,7 @@
     Tag  test-input
     foo  bar
     tmpl "{{print \"inside double quotes\"}}\nnew line"
+    multiline foo\nbar
 
 # [OUTPUT]
 #     Name  go-test-output-plugin

--- a/testdata/input/input.go
+++ b/testdata/input/input.go
@@ -18,6 +18,7 @@ func init() {
 type inputPlugin struct {
 	foo            string
 	tmpl           *template.Template
+	multilineSplit []string
 	collectCounter metric.Counter
 	log            plugin.Logger
 }
@@ -30,6 +31,7 @@ func (plug *inputPlugin) Init(ctx context.Context, fbit *plugin.Fluentbit) error
 	}
 
 	plug.foo = fbit.Conf.String("foo")
+	plug.multilineSplit = strings.Split(fbit.Conf.String("multiline"), "\n")
 	plug.collectCounter = fbit.Metrics.NewCounter("collect_total", "Total number of collects", "go-test-input-plugin")
 	plug.log = fbit.Logger
 	return nil
@@ -61,10 +63,11 @@ func (plug inputPlugin) Collect(ctx context.Context, ch chan<- plugin.Message) e
 
 			ch <- plugin.Message{
 				Time: time.Now(),
-				Record: map[string]string{
-					"message": "hello from go-test-input-plugin",
-					"foo":     plug.foo,
-					"tmpl":    buff.String(),
+				Record: map[string]any{
+					"message":         "hello from go-test-input-plugin",
+					"foo":             plug.foo,
+					"tmpl_out":        buff.String(),
+					"multiline_split": plug.multilineSplit,
 				},
 			}
 		}


### PR DESCRIPTION
Unescape literal new line character.

When using a config like this:

```ini
[INTPUT]
    split_me "foo\nbar"
```

This was unquoted and the `\n` inside was treated as a new line character, so doing a `strings.Split(splitMe, "\n")` worked as expected `[]string{"foo", "bar"}`.

But when using a config like this:

```ini
[INTPUT]
    split_me foo\nbar
```

Since it does not have quotes, it was not unquoted and the `\n` was not treated as a new-line character but as a literal `\\n`. Hence doing the same split results in `[]string{"foo\\nbar"}`.
