### PR TITLE
cshared: exit before sending any records.

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -165,12 +165,15 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		// fluent-bit to kick in before any remaining data has not been GC'ed
 		// causing a sigsegv.
 		defer runtime.GC()
+	default:
+		break
 	}
 
 	return input.FLB_OK
 }
 
 // FLBPluginInputCleanupCallback releases the memory used during the input callback
+//
 //export FLBPluginInputCleanupCallback
 func FLBPluginInputCleanupCallback(data unsafe.Pointer) int {
 	C.free(data)

--- a/cshared_test.go
+++ b/cshared_test.go
@@ -1,0 +1,40 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+type testPluginInputCallback struct {
+}
+
+func (t testPluginInputCallback) Init(ctx context.Context, fbit *Fluentbit) error {
+	return nil
+}
+
+func (t testPluginInputCallback) Collect(ctx context.Context, ch chan<- Message) error {
+	return nil
+}
+
+func TestInputCallbackCtrlC(t *testing.T) {
+	theInput = testPluginInputCallback{}
+	cdone := make(chan bool)
+	timeout := time.NewTimer(1 * time.Second)
+	ptr := unsafe.Pointer(nil)
+
+	initWG.Done()
+	registerWG.Done()
+
+	go func() {
+		FLBPluginInputCallback(&ptr, nil)
+		cdone <- true
+	}()
+
+	select {
+	case <-cdone:
+	case <-timeout.C:
+		t.Fail()
+	}
+}


### PR DESCRIPTION
# Summary

By default leave the Collect() callback when no records are received by the golang side so `ctrl+c` works again.

## Description

On the fluent-bit side all threaded plugins have a main event loop. This event loop is the one that receives requests to exit. This very same event loop responds to the exit request when it finishes.

With the current version of the golang plugin API the Collect() callback does not return until it receives at least one record. This also means that if the plugin stops sending record from the golang side `ctrl+c` should stop working.

This patch simply breaks out of the loop if there is no record received. This should not pose any problems since Collect() will be invoked again. This could pose a problem for plugins that expect Collect() to be invoked only once.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205327085986728