### PR TITLE
[FEATURE] buffered channel drain next

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -183,6 +183,9 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 				case <-t.C:
 					buflock.Unlock()
 					buflock.Lock()
+				case <-runCtx.Done():
+					buflock.Unlock()
+					return
 				}
 				buflock.Unlock()
 			}

--- a/cshared.go
+++ b/cshared.go
@@ -38,7 +38,7 @@ var (
 
 const (
 	collectInterval = time.Nanosecond * 1000
-
+	maxBufferedMessages = 300000
 )
 
 // FLBPluginRegister registers a plugin in the context of the fluent-bit runtime, a name and description
@@ -141,7 +141,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 	once.Do(func() {
 		runCtx, runCancel = context.WithCancel(context.Background())
 		// we need to configure this part....
-		theChannel = make(chan Message, 300000)
+		theChannel = make(chan Message, maxBufferedMessages)
 		// do we need to buffer this part???
 		cbuf := make(chan Message, 16)
 

--- a/cshared.go
+++ b/cshared.go
@@ -138,7 +138,6 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		return input.FLB_RETRY
 	}
 
-	var err error
 	once.Do(func() {
 		runCtx, runCancel = context.WithCancel(context.Background())
 		// we need to configure this part....
@@ -196,10 +195,6 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 			}
 		}(cbuf)
 	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "run: %s\n", err)
-		return input.FLB_ERROR
-	}
 
 	buf := bytes.NewBuffer([]byte{})
 

--- a/cshared.go
+++ b/cshared.go
@@ -36,6 +36,11 @@ var (
 	buflock    sync.Mutex
 )
 
+const (
+	collectInterval = time.Nanosecond * 1000
+
+)
+
 // FLBPluginRegister registers a plugin in the context of the fluent-bit runtime, a name and description
 // can be provided.
 //
@@ -146,7 +151,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		// behavior and also simulate the original behavior for those plugins that
 		// do not hold on to the thread.
 		go func(runCtx context.Context) {
-			t := time.NewTicker(1000 * time.Nanosecond)
+			t := time.NewTicker(collectInterval)
 			defer t.Stop()
 
 			for {

--- a/cshared.go
+++ b/cshared.go
@@ -257,7 +257,8 @@ func FLBPluginInputCleanupCallback(data unsafe.Pointer) int {
 // plugin in the pipeline, a data pointer, length and a tag are passed to the plugin interface implementation.
 //
 //export FLBPluginFlush
-//nolint:funlen,gocognit,gocyclo //ignore length requirement for this function, TODO: refactor into smaller functions.
+// TODO: refactor into smaller functions.
+//nolint:funlen //ignore length requirement for this function
 func FLBPluginFlush(data unsafe.Pointer, clength C.int, ctag *C.char) int {
 	initWG.Wait()
 

--- a/cshared.go
+++ b/cshared.go
@@ -146,6 +146,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		}()
 		go func(cbuf chan Message) {
 			t := time.NewTicker(1 * time.Second)
+			defer t.Stop()
 			for {
 				buflock.Lock()
 				select {

--- a/cshared.go
+++ b/cshared.go
@@ -65,7 +65,7 @@ func FLBPluginRegister(def unsafe.Pointer) int {
 }
 
 // FLBPluginInit this method gets invoked once by the fluent-bit runtime at initialisation phase.
-// here all the plugin context should be initialised and any data or flag required for
+// here all the plugin context should be initialized and any data or flag required for
 // plugins to execute the collect or flush callback.
 //
 //export FLBPluginInit
@@ -120,7 +120,7 @@ func FLBPluginInit(ptr unsafe.Pointer) int {
 }
 
 // FLBPluginInputCallback this method gets invoked by the fluent-bit runtime, once the plugin has been
-// initialised, the plugin implementation is responsible for handling the incoming data and the context
+// initialized, the plugin implementation is responsible for handling the incoming data and the context
 // that gets past, for long-living collectors the plugin itself should keep a running thread and fluent-bit
 // will not execute further callbacks.
 //
@@ -143,7 +143,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 
 		// Most plugins expect Collect to be invoked once and then takes over the
 		// input thread by running in an infinite loop. Here we simulate this
-		// behaviour and also simulate the original behaviour for those plugins that
+		// behavior and also simulate the original behavior for those plugins that
 		// do not hold on to the thread.
 		go func(runCtx context.Context) {
 			t := time.NewTicker(1000 * time.Nanosecond)
@@ -155,7 +155,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 					return
 				case <-t.C:
 					if err := theInput.Collect(runCtx, cbuf); err != nil {
-						fmt.Fprintf("Error collecting input: %s\n", err)
+						fmt.Fprintf(os.Stderr, "Error collecting input: %s\n", err)
 					}
 				}
 			}

--- a/cshared.go
+++ b/cshared.go
@@ -134,7 +134,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 	var err error
 	once.Do(func() {
 		runCtx, runCancel = context.WithCancel(context.Background())
-		theChannel = make(chan Message, 16)
+		theChannel = make(chan Message, 256)
 		go func() {
 			err = theInput.Collect(runCtx, theChannel)
 		}()

--- a/cshared.go
+++ b/cshared.go
@@ -159,7 +159,6 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 				case <-t.C:
 					buflock.Unlock()
 					buflock.Lock()
-				default:
 				}
 				buflock.Unlock()
 			}

--- a/cshared.go
+++ b/cshared.go
@@ -152,8 +152,9 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		theChannel = make(chan Message, maxBufferedMessages)
 
 		// We use a timer instead of a Ticker so that it is not
-		// rescheduled during a cancel().
-		t := time.NewTimer(collectInterval)
+		// rescheduled during a cancel(). We start the timer at 0
+		// so the first interval gets executed immediately.
+		t := time.NewTimer(0)
 
 		go func(t *time.Timer, theChannel chan<- Message) {
 			for {

--- a/cshared.go
+++ b/cshared.go
@@ -155,7 +155,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 					return
 				case <-t.C:
 					if err := theInput.Collect(runCtx, cbuf); err != nil {
-						fmt.Fprintf(os.Stderr, "Error collecting input: %s\n", err)
+						fmt.Fprintf(os.Stderr, "Error collecting input: %s\n", err.Error())
 					}
 				}
 			}

--- a/cshared.go
+++ b/cshared.go
@@ -142,7 +142,9 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 		cbuf := make(chan Message, 16)
 
 		go func() {
-			err = theInput.Collect(runCtx, cbuf)
+			if err := theInput.Collect(runCtx, cbuf); err != nil {
+				fmt.Fprintf("Error collecting input: %s\n", err)
+			}
 		}()
 		go func(cbuf chan Message) {
 			t := time.NewTicker(1 * time.Second)

--- a/cshared.go
+++ b/cshared.go
@@ -132,13 +132,6 @@ func FLBPluginInit(ptr unsafe.Pointer) int {
 	return input.FLB_OK
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // FLBPluginInputCallback this method gets invoked by the fluent-bit runtime, once the plugin has been
 // initialized, the plugin implementation is responsible for handling the incoming data and the context
 // that gets past, for long-living collectors the plugin itself should keep a running thread and fluent-bit
@@ -154,8 +147,6 @@ func FLBPluginInputCallback(data *unsafe.Pointer, csize *C.size_t) int {
 	}
 
 	if runCtx == nil {
-		fmt.Println("EXEC ONCE")
-
 		runCtx, runCancel = context.WithCancel(context.Background())
 		theChannel = make(chan Message, maxBufferedMessages)
 

--- a/cshared_test.go
+++ b/cshared_test.go
@@ -2,29 +2,34 @@ package plugin
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unsafe"
 )
 
-type testPluginInputCallback struct{}
+type testPluginInputCallbackCtrlC struct{}
 
-func (t testPluginInputCallback) Init(ctx context.Context, fbit *Fluentbit) error {
+func (t testPluginInputCallbackCtrlC) Init(ctx context.Context, fbit *Fluentbit) error {
 	return nil
 }
 
-func (t testPluginInputCallback) Collect(ctx context.Context, ch chan<- Message) error {
+func (t testPluginInputCallbackCtrlC) Collect(ctx context.Context, ch chan<- Message) error {
 	return nil
+}
+
+func init() {
+	initWG.Done()
+	registerWG.Done()
 }
 
 func TestInputCallbackCtrlC(t *testing.T) {
-	theInput = testPluginInputCallback{}
+	theInput = testPluginInputCallbackCtrlC{}
 	cdone := make(chan bool)
 	timeout := time.NewTimer(1 * time.Second)
 	ptr := unsafe.Pointer(nil)
-
-	initWG.Done()
-	registerWG.Done()
 
 	go func() {
 		FLBPluginInputCallback(&ptr, nil)
@@ -33,6 +38,108 @@ func TestInputCallbackCtrlC(t *testing.T) {
 
 	select {
 	case <-cdone:
+		runCancel()
+	case <-timeout.C:
+		t.Fail()
+	}
+}
+
+var testPluginInputCallbackInfiniteFuncs atomic.Int64
+
+type testPluginInputCallbackInfinite struct{}
+
+func (t testPluginInputCallbackInfinite) Init(ctx context.Context, fbit *Fluentbit) error {
+	return nil
+}
+
+func (t testPluginInputCallbackInfinite) Collect(ctx context.Context, ch chan<- Message) error {
+	go func(ch chan<- Message) {
+		testPluginInputCallbackInfiniteFuncs.Add(1)
+		for {
+			ch <- Message{
+				Time: time.Now(),
+				Record: map[string]string{
+					"Foo": "BAR",
+				},
+			}
+		}
+	}(ch)
+	return nil
+}
+
+// TestInputCallbackInfinite is a test for the main method most plugins
+// use where they do not return from the first invocation of collect.
+func TestInputCallbackInfinite(t *testing.T) {
+	theInput = testPluginInputCallbackInfinite{}
+	cdone := make(chan bool)
+	timeout := time.NewTimer(10 * time.Second)
+	ptr := unsafe.Pointer(nil)
+
+	go func() {
+		for {
+			FLBPluginInputCallback(&ptr, nil)
+			time.Sleep(1 * time.Second)
+
+			if ptr != nil {
+				cdone <- true
+			}
+		}
+	}()
+
+	select {
+	case <-cdone:
+		runCancel()
+		// Test the assumption that only a single goroutine is
+		// ingesting records.
+		if testPluginInputCallbackInfiniteFuncs.Load() != 1 {
+			t.Fail()
+		}
+	case <-timeout.C:
+		t.Fail()
+	}
+}
+
+type testInputCallbackInfiniteConcurrent struct{}
+
+var concurrentWait sync.WaitGroup
+
+func (t testInputCallbackInfiniteConcurrent) Init(ctx context.Context, fbit *Fluentbit) error {
+	return nil
+}
+
+func (t testInputCallbackInfiniteConcurrent) Collect(ctx context.Context, ch chan<- Message) error {
+	for i := 0; i < 64; i++ {
+		go func(ch chan<- Message, id int) {
+			ch <- Message{
+				Time: time.Now(),
+				Record: map[string]string{
+					"ID": fmt.Sprintf("%d", id),
+				},
+			}
+			concurrentWait.Done()
+		}(ch, i)
+	}
+	return nil
+}
+
+// TestInputCallbackInfiniteConcurrent is meant to make sure we do not
+// break anythin with respect to concurrent ingest.
+func TestInputCallbackInfiniteConcurrent(t *testing.T) {
+	theInput = testInputCallbackInfiniteConcurrent{}
+	cdone := make(chan bool)
+	timeout := time.NewTimer(10 * time.Second)
+	ptr := unsafe.Pointer(nil)
+
+	concurrentWait.Add(64)
+	go func() {
+		FLBPluginInputCallback(&ptr, nil)
+		concurrentWait.Wait()
+		cdone <- true
+	}()
+
+	select {
+	case <-cdone:
+		runCancel()
 	case <-timeout.C:
 		t.Fail()
 	}


### PR DESCRIPTION
# Summary

This is a version of calyptia/plugin#34 which removes one of the intermediate buffers and also makes the size of the buffer channel configurable via the `go.MaxBufferedMessages` configuration option.

I have also added tests to make sure that this new model works and does not run into deadlocks.
