### PR TITLE
log: pass entire log as string using '%s' fmt to avoid fmt bugs.

### DIFF
--- a/input/flb_input.h
+++ b/input/flb_input.h
@@ -62,7 +62,8 @@ void input_log_print_novar(void *plugin, int log_level, const char* message)
 {
     struct flbgo_input_plugin *p = plugin;
     if (p->api->input_log_check(p->i_ins, log_level)) {
-        p->api->log_print(log_level, NULL, 0, message);
+        /* all formating is done in golang, avoid fmt string bugs. */
+        p->api->log_print(log_level, NULL, 0, "%s", message);
     }
 }
 

--- a/output/flb_output.h
+++ b/output/flb_output.h
@@ -60,7 +60,8 @@ void output_log_print_novar(void *plugin, int log_level, const char* message)
 {
     struct flbgo_output_plugin *p = plugin;
     if (p->api->output_log_check(p->o_ins, log_level)) {
-        p->api->log_print(log_level, NULL, 0, message);
+        /* all formating is done in golang, avoid fmt string bugs. */
+        p->api->log_print(log_level, NULL, 0, "%s", message);
     }
 }
 


### PR DESCRIPTION
This basically escapes all log messages so they cannot cause crashes or be exploited.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205602086260274