### PR TITLE
output: Updated plugin headers and output.go to reflect proposed change in fluent-bit

### DIFF
--- a/examples/out_gstdout/README.md
+++ b/examples/out_gstdout/README.md
@@ -24,6 +24,18 @@ func FLBPluginRegister(ctx unsafe.Pointer) int {
 
 This function is invoked at start time _before_ any configuration is done inside the engine.
 
+### Setting event type 
+
+By default, Fluent Bit Golang plugins process logs. Optionally, the event_type 
+can be set to allow for metrics by using `output.FLBPluginRegisterWithEventType`. 
+
+```go
+//export FLBPluginRegister 
+func FLBPluginRegister(def unsafe.Pointer) int {
+	return output.FLBPluginRegisterWithEventType(ctx, output.FLB_OUTPUT_METRICS, "gstdout", "Stdout GO!")
+}
+```
+
 ## Plugin Initialization
 
 Before the engine starts, it initialize all plugins that were requested to start. Upon initialization a configuration context already exists, so the plugin can ask for configuration parameters or do any other internal checks. E.g:

--- a/examples/out_multiinstance/README.md
+++ b/examples/out_multiinstance/README.md
@@ -29,6 +29,18 @@ func FLBPluginRegister(def unsafe.Pointer) int {
 This function is invoked at start time _before_ any configuration is done
 inside the engine.
 
+### Setting event type 
+
+By default, Fluent Bit Golang plugins process logs. Optionally, the event_type 
+can be set to allow for metrics by using `output.FLBPluginRegisterWithEventType`. 
+
+```go
+//export FLBPluginRegister 
+func FLBPluginRegister(def unsafe.Pointer) int {
+	return output.FLBPluginRegisterWithEventType(ctx, output.FLB_OUTPUT_METRICS, "multiinstance", "Testing multiple instances")
+}
+```
+
 ## Plugin Initialization
 
 Before the engine starts, it initializes all plugins that were configured.

--- a/input/flb_plugin.h
+++ b/input/flb_plugin.h
@@ -44,6 +44,7 @@ struct flb_plugin_proxy_def {
     int flags;
     char *name;
     char *description;
+    int  event_type;
 };
 
 #endif

--- a/output/flb_output.h
+++ b/output/flb_output.h
@@ -20,6 +20,10 @@
 #ifndef FLBGO_OUTPUT_H
 #define FLBGO_OUTPUT_H
 
+#define FLB_OUTPUT_LOGS    1
+#define FLB_OUTPUT_METRICS 2
+#define FLB_OUTPUT_TRACES  4
+
 struct flb_api {
     char *(*output_get_property) (char *, void *);
     char *_;

--- a/output/flb_plugin.h
+++ b/output/flb_plugin.h
@@ -44,6 +44,7 @@ struct flb_plugin_proxy_def {
     int flags;
     char *name;
     char *description;
+    int  event_type;
 };
 
 #endif

--- a/output/output.go
+++ b/output/output.go
@@ -44,6 +44,10 @@ const (
 	FLB_LOG_WARN  = C.FLB_LOG_WARN
 	FLB_LOG_INFO  = C.FLB_LOG_INFO
 	FLB_LOG_DEBUG = C.FLB_LOG_DEBUG
+
+	FLB_OUTPUT_LOGS    = C.FLB_OUTPUT_LOGS
+	FLB_OUTPUT_METRICS = C.FLB_OUTPUT_METRICS
+	FLB_OUTPUT_TRACES  = C.FLB_OUTPUT_TRACES
 )
 
 type (
@@ -63,6 +67,18 @@ func FLBPluginRegister(def unsafe.Pointer, name, desc string) int {
 	p.flags = 0
 	p.name = C.CString(name)
 	p.description = C.CString(desc)
+	p.event_type = 0
+	return 0
+}
+
+func FLBPluginRegisterWithEventType(def unsafe.Pointer, eventType int, name, desc string) int {
+	p := (*FLBPluginProxyDef)(def)
+	p._type = FLB_PROXY_OUTPUT_PLUGIN
+	p.proxy = FLB_PROXY_GOLANG
+	p.flags = 0
+	p.name = C.CString(name)
+	p.description = C.CString(desc)
+	p.event_type = C.int(eventType)
 	return 0
 }
 


### PR DESCRIPTION
Related to changes proposed in [PR #11011](https://github.com/fluent/fluent-bit/pull/11011) in fluent-bit. 

This PR adds a new function FLBPluginRegisterWithEventType that enables setting the event type for output plugins. This change updates the header files to match the proposed changes in the fluent-bit repository, and adds documentation in addition to this new feature. (Reflecting changes proposed in fluent-bit-go: [PR 80](https://github.com/fluent/fluent-bit-go/pull/80)

The proposed changes in go: 
Adding `event_type` to the `flb_plugin_proxy_def` struct. This allows for the setting of `event_type` to a value other than the default log only initialization.

In the `flb_plugin_proxy_register` function default behavior is enforced by checking for unset `event_type` values. When unset (a value of 0) then log behavior is defaulted. No need for incorrect value checking since this was not a set field in the past. Unset fields are set as current behavior dictates and future use cases using incorrect values can be treated as user error.

Input use case does not use event-type and is unaffected by this change. (Only a struct change but no change to logic or behavior)

