### PR TITLE
fix: WaitGroup panic in FLBPluginRegister and V2 msgpack decode error

### DIFF
--- a/cshared.go
+++ b/cshared.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -51,6 +52,7 @@ var (
 func FLBPluginPreRegister(hotReloading C.int) int {
 	if hotReloading == C.int(1) {
 		registerWG.Add(1)
+		atomic.AddInt32(&registerWGCounter, 1)
 	}
 
 	return input.FLB_OK
@@ -61,7 +63,7 @@ func FLBPluginPreRegister(hotReloading C.int) int {
 //
 //export FLBPluginRegister
 func FLBPluginRegister(def unsafe.Pointer) int {
-	defer registerWG.Done()
+	defer registerWGDone()
 
 	if theInput == nil && theOutput == nil && theCustom == nil {
 		fmt.Fprintf(os.Stderr, "no input or output or custom registered\n")
@@ -516,8 +518,6 @@ func decodeMsg(dec *msgpack.Decoder, tag string) (Message, error) {
 		if err = msgpack.Unmarshal(eventWithMetadata[0], &eventTime); err != nil {
 			return out, fmt.Errorf("msgpack unmarshal event time with metadata: %w", err)
 		}
-
-		return out, fmt.Errorf("msgpack unmarshal event time: %w", err)
 	}
 
 	var record map[string]any

--- a/plugin.go
+++ b/plugin.go
@@ -23,16 +23,30 @@ var (
 )
 
 var (
-	registerWG sync.WaitGroup
-	initWG     sync.WaitGroup
-	runCtx     context.Context
-	runCancel  context.CancelFunc
-	theChannel chan Message
+	registerWG        sync.WaitGroup
+	registerWGCounter int32 // tracks Add/Done balance to prevent negative WaitGroup panic
+	initWG            sync.WaitGroup
+	runCtx            context.Context
+	runCancel         context.CancelFunc
+	theChannel        chan Message
 )
 
 func init() {
 	registerWG.Add(1)
+	atomic.AddInt32(&registerWGCounter, 1)
 	theChannel = nil
+}
+
+// registerWGDone safely calls registerWG.Done() only if the WaitGroup counter
+// is positive. This prevents a panic when FLBPluginRegister is called without
+// a prior FLBPluginPreRegister (which only happens during hot-reload).
+func registerWGDone() {
+	if atomic.AddInt32(&registerWGCounter, -1) >= 0 {
+		registerWG.Done()
+	} else {
+		// Counter went negative — restore it and skip Done().
+		atomic.AddInt32(&registerWGCounter, 1)
+	}
 }
 
 type Fluentbit struct {


### PR DESCRIPTION
## Summary

This PR fixes two bugs that affect Go output plugins running under Fluent Bit 5.x. One of these bugs is talked about in [THIS ISSUE on the fluent-bit project](https://github.com/fluent/fluent-bit/issues/11215)

## Bug 1: WaitGroup panic — negative counter in FLBPluginRegister

### Symptom

```
panic: sync: negative WaitGroup counter

goroutine 17 [running, locked to thread]:
sync.(*WaitGroup).Add(...)
sync.(*WaitGroup).Done(...)
github.com/calyptia/plugin.FLBPluginRegister(...)
```

### Root Cause

`FLBPluginRegister` (cshared.go:64) unconditionally calls `registerWG.Done()`:

```go
func FLBPluginRegister(def unsafe.Pointer) int {
    defer registerWG.Done()
    ...
}
```

The `init()` function in plugin.go calls `registerWG.Add(1)`, setting the counter to 1. However, `FLBPluginPreRegister` only calls `registerWG.Add(1)` when `hotReloading == C.int(1)`:

```go
func FLBPluginPreRegister(hotReloading C.int) int {
    if hotReloading == C.int(1) {
        registerWG.Add(1)
    }
    return input.FLB_OK
}
```

On normal startup (no hot-reload), the flow is:
1. `init()` → counter = 1
2. `FLBPluginPreRegister(0)` → no-op, counter stays 1  
3. `FLBPluginRegister` → `Done()` → counter = 0 ✓

But if Fluent Bit calls `FLBPluginRegister` a second time (which can happen during plugin re-registration or internal retries), the counter goes 0 → -1 → **panic**.

### Fix

Introduce `registerWGDone()` with an atomic counter guard that safely skips `Done()` if the counter would go negative.

### Reproduction

Any Go output plugin on Fluent Bit 5.0.5 with `Hot_Reload On` disabled (the common case) and multiple output instances.

---

## Bug 2: V2 msgpack decode returns error on successful parse

### Symptom

Valid Fluent Bit V2 format records (the default since Fluent Bit 3.x) are treated as decode failures, causing data loss or retry storms.

### Root Cause

In `decodeFullEntry()` (cshared.go), after successfully parsing a V2 format `[timestamp, metadata]` array:

```go
eventTime := &EventTime{}
if err := msgpack.Unmarshal(entry[0], &eventTime); err != nil {
    var eventWithMetadata []msgpack.RawMessage
    if err = msgpack.Unmarshal(entry[0], &eventWithMetadata); err != nil {
        return out, fmt.Errorf("msgpack unmarshal event with metadata: %w", err)
    }

    if len(eventWithMetadata) < 1 {
        return out, fmt.Errorf("...")
    }

    if err = msgpack.Unmarshal(eventWithMetadata[0], &eventTime); err != nil {
        return out, fmt.Errorf("msgpack unmarshal event time with metadata: %w", err)
    }

    // BUG: returns error even though parsing succeeded
    return out, fmt.Errorf("msgpack unmarshal event time: %w", err)
}
```

After line 516 succeeds (`eventTime` is valid, `err` is nil), line 520 unconditionally returns a non-nil error (wrapping nil). The function should instead fall through to record parsing (lines 523+).

### Fix

Remove the erroneous `return` statement so that successfully parsed V2 event times proceed to record unmarshaling.

---

## Context

Both bugs were discovered while building custom Go output plugins processing ~3.4M records/min across 40+ plugin instances in a production Kubernetes logging pipeline (Fluent Bit 5.0.5, linux/arm64 and linux/amd64).