### PR TITLE
ci: Upgrade GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
           TARGETARCH: amd64
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "^1.23"
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,22 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - Hadolint
     steps:
-      - uses: actions/checkout@v4
-        # Ignores do not work: https://github.com/reviewdog/action-hadolint/issues/35 is resolved
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: reviewdog/action-hadolint@v1
 
   shellcheck-pr:
     runs-on: ubuntu-latest
     name: PR - Shellcheck
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ludeeus/action-shellcheck@master
 
   actionlint-pr:
     runs-on: ubuntu-latest
     name: PR - Actionlint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -38,8 +37,7 @@ jobs:
     name: PR - Reusable workflow linting
     steps:
       # We probably should target this on only workflow changes but the complexity of doing that is a lot more than just letting the grep run.
-      - uses: actions/checkout@v4
-      # Recursive grep or any workflow using a local reusable workflow but not ending in @main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
           if [[ $(grep -R -E 'uses:[ ]*calyptia/enterprise/.github/workflows/.*@[^main].*$' .github/workflows/*.y*ml| wc -l) -gt 0 ]]; then
             echo "Found reusable workflow on non-main branch"
@@ -53,7 +51,7 @@ jobs:
       runs-on: ubuntu-latest
       name: PR - Markdownlint
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         - name: Run markdownlint
           uses: actionshub/markdownlint@v3.1.4
 
@@ -61,8 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     name: PR - GO lint
     steps:
-      - uses: actions/checkout@v4
-
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install cmetrics
         env:
           TARGETARCH: amd64

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,7 @@ jobs:
     name: PR - Hadolint
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # Ignores do not work: https://github.com/reviewdog/action-hadolint/issues/35 is resolved
       - uses: reviewdog/action-hadolint@v1
 
   shellcheck-pr:
@@ -38,6 +39,7 @@ jobs:
     steps:
       # We probably should target this on only workflow changes but the complexity of doing that is a lot more than just letting the grep run.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Recursive grep or any workflow using a local reusable workflow but not ending in @main
       - run: |
           if [[ $(grep -R -E 'uses:[ ]*calyptia/enterprise/.github/workflows/.*@[^main].*$' .github/workflows/*.y*ml| wc -l) -gt 0 ]]; then
             echo "Found reusable workflow on non-main branch"


### PR DESCRIPTION
## Summary
- Upgrades all JS-based GitHub Actions from Node 20 (or older) to Node 22+ versions
- SHA-pins all upgraded action references for supply-chain security
- Addresses upcoming [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

[sc-178410](https://app.shortcut.com/chronosphere/story/178410)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify workflow behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)