### PR TITLE
ci: Upgrade remaining GitHub Actions to Node 22+ runtimes [sc-178410]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
         run: go mod download
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ secrets.CI_USERNAME }}
@@ -87,14 +87,14 @@ jobs:
       - name: Import GPG key
         if: startsWith(github.ref, 'refs/tags/')
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
           gpg_private_key: ${{ secrets.CALYPTIA_GPG_KEY }}
           passphrase: ${{ secrets.CALYPTIA_GPG_KEY_PASSPHRASE }}
 
       - name: Run GoReleaser
         if: startsWith(github.ref, 'refs/tags/')
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: latest
           args: release --clean


### PR DESCRIPTION
## Summary
- Upgrades remaining JS-based GitHub Actions from Node 20 to Node 22+ versions (second wave)
- SHA-pins all upgraded action references for supply-chain security
- Covers docker/*, google-github-actions/*, aws-actions/*, azure/*, goreleaser/*, helm/kind-action, crazy-max/ghaction-import-gpg, and first-wave stragglers missed by a regex bug
- Addresses upcoming [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)

[sc-178410](https://app.shortcut.com/chronosphere/story/178410)

## Test plan
- [ ] CI passes on this branch
- [ ] Verify workflow behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)